### PR TITLE
Fix Bug with Missing First Node

### DIFF
--- a/stitcher/stitcher.py
+++ b/stitcher/stitcher.py
@@ -149,6 +149,6 @@ class Stitcher:
         sys.exit(1)
 
     def _assign_id(self, node_str):
-        if not self.node_to_id.get(node_str, None):
+        if (self.node_to_id.get(node_str, None) is None):
             self.node_to_id[node_str] = self.id_cnt
             self.id_cnt += 1

--- a/stitcher/stitcher.py
+++ b/stitcher/stitcher.py
@@ -149,6 +149,6 @@ class Stitcher:
         sys.exit(1)
 
     def _assign_id(self, node_str):
-        if (self.node_to_id.get(node_str, None) is None):
+        if self.node_to_id.get(node_str, None) is None:
             self.node_to_id[node_str] = self.id_cnt
             self.id_cnt += 1


### PR DESCRIPTION
# Description

While testing PyCG-Stitch by executing the micro-benchmark, I noticed that on the produced output:
``` json
{
  "edges": [
    [0, 1], 
    [2, 3], 
    [2, 4], 
    [2, 5],
    [3, 6],
    [4, 7], 
    [5, 8]
  ],
  "nodes": {
    "1": {
      "URI": "fasten://trans-dep2$1.0/trans_dep2.trans_dep2/smth()",
      "metadata": {}
    },
    "2": {
      "URI": "fasten://root$1.0/root.root/",
      "metadata": {}
    },
    "3": {
      "URI": "fasten://root$1.0/root.root/A.fn()",
      "metadata": {}
    },
    "4": {
      "URI": "fasten://root$1.0/root.root/func2()",
      "metadata": {}
    },
    "5": {
      "URI": "fasten://trans-dep1$1.0/trans_dep1.trans_dep1/ClsPar.__init__()",
      "metadata": {}
    },
    "6": {
      "URI": "fasten://dep1$1.0/dep1.dep1/Cls.dep_fn()",
      "metadata": {}
    },
    "7": {
      "URI": "fasten://dep2$1.0/dep2.dep2/func()",
      "metadata": {}
    },
    "8": {
      "URI": "fasten://trans-dep1$1.0/trans_dep1.trans_dep1/fun()",
      "metadata": {}
    }
  }
}
 ```
 The node 0 of the call graph was missing from the nodes list.
 
After some investigation, I noticed that this happends due to a bug.

More specifically, we have a dictionary  named ```node_to_id``` which has as a key all the strings of the unique nodes (modules) and as value a unique integer id, which is auto-incrementing.

On the ```_assign_id()``` method:
https://github.com/fasten-project/pycg-stitch/blob/ed5d10957c48924d54bc138773031f4facc46c27/stitcher/stitcher.py#L151-L154

We check whether a node exists on the dictionary, and if not we add it by assigning to it a unique id.
Therefore, the method ```self.node_to_id.get(node_str, None)``` returns an integer if it finds the specified node, or None otherwise.
In order to check whether the string exists, we use the ```if not``` operator:
https://github.com/fasten-project/pycg-stitch/blob/ed5d10957c48924d54bc138773031f4facc46c27/stitcher/stitcher.py#L152

The problem is, that in Python,  zero values are false and non-zero values are true.
Therefore, if the node with id equal to 0 is revisited at some point, the if statement will be true, meaning that the program will falsely assume that the node does not exist in the dictionary, and consequently it will erase it and assign to it a new id.


Therefore, in order to fix this issue, I modified the if statement to check whether the method ```self.node_to_id.get(node_str, None)``` returns None or not, in order to preserve the node having id equal to 0.


